### PR TITLE
+fix lacking of header file `stdint.h` bug:

### DIFF
--- a/pcs/pcs_defs.h
+++ b/pcs/pcs_defs.h
@@ -2,6 +2,7 @@
 #define _PCS_DEFS_H
 
 #include <curl/curl.h>
+#include <stdint.h>
 
 #if defined(_MSC_VER) || defined(__BORLANDC__)
 typedef __int64 int64_t;


### PR DESCRIPTION
    Linux Distribution:
        Distributor ID: Ubuntu
        Description:    Ubuntu 14.04.1 LTS
        Release:        14.04
        Codename:       trusty
    Error:
        pcs/pcs_fileinfo.h:8:2: error: unknown type name ‘uint64_t’
    Resolved:
        because of the lack of header file `stdint.h`
      so add `#include <stdint.h>` to pcs/pcs_defs.h