### PR TITLE
(fix #55) 修改yunData.setData()内数据的获取方式。

### DIFF
--- a/pcs/pcs.c
+++ b/pcs/pcs.c
@@ -221,7 +221,8 @@ static char *pcs_get_yunData(const char *html, const char *key)
 		if (*p == key[0] && pcs_utils_streq(p, key, i)) {
 			tmp = p + i;
 			PCS_SKIP_SPACE(tmp);
-			if (*tmp != '(') continue; tmp++;
+			//if (*tmp != '(') continue; tmp++;
+			if (*tmp != '=') continue; tmp++;
 			PCS_SKIP_SPACE(tmp);
 			if (*tmp != '{') continue;
 			end = tmp;
@@ -1347,7 +1348,8 @@ PCS_API PcsRes pcs_islogin(Pcs handle)
 	}
 	if (!pcs->bdstoken || strlen(pcs->bdstoken) == 0) {
 		cJSON *json, *item;
-		char *jsonData = pcs_get_yunData(html, "yunData.setData");
+		char *jsonData = pcs_get_yunData(html, "context");
+		//char *jsonData = pcs_get_yunData(html, "yunData.setData");
 		if (!jsonData) {
 			return PCS_NOT_LOGIN;
 		}


### PR DESCRIPTION
原本括号内直接就是一段jsonp数据，现在则是预先将jsonp加载到一个变量（context）里然后将变量传进去。

原先的代码由于取到yunData.setData后面的"("之后，无法取到"{"，函数退出之后搜索指针又没有向前推移，导致死循环，程序停止响应。