### PR TITLE
修正因百度盘首页结构变化导致检测登录卡死的问题 (Issue #60)

### DIFF
--- a/pcs/pcs.c
+++ b/pcs/pcs.c
@@ -221,10 +221,13 @@ static char *pcs_get_yunData(const char *html, const char *key)
 		if (*p == key[0] && pcs_utils_streq(p, key, i)) {
 			tmp = p + i;
 			PCS_SKIP_SPACE(tmp);
-			//if (*tmp != '(') continue; tmp++;
-			if (*tmp != '=') continue; tmp++;
+			if (*tmp != '=') {
+				p++; continue;
+			}tmp++;
 			PCS_SKIP_SPACE(tmp);
-			if (*tmp != '{') continue;
+			if (*tmp != '{') {
+				p++; continue;
+			}
 			end = tmp;
 
 			while (*end) {


### PR DESCRIPTION
主要是自己上次偷了懒没有从根本上修正之前的bug。
于是百度大幅度调整了网盘首页js和登录信息的位置，导致程序又死循环了。