### PR TITLE
add lib path for ssl.

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@ CYGWIN_CCFLAGS =
 endif
 
 ifeq ($(LC_OS_NAME), darwin)
-APPLE_CCFLAGS = -I/usr/local/opt/openssl/include
+APPLE_CCFLAGS = -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib
 else
 APPLE_CCFLAGS = 
 endif


### PR DESCRIPTION
Got ld error on my mac and fixed:

cc -o bin/pcs bin/shell_arg.o bin/shell.o bin/dir.o bin/rb_tree_misc.o bin/rb_tree_stack.o bin/red_black_tree.o bin/shell_utils.o bin/hashtable.o -D_FILE_OFFSET_BITS=64  -I/usr/local/opt/openssl/include -L./bin -lpcs -lm -lcurl -lssl -lcrypto -lpthread
ld: library not found for -lssl