### PR TITLE
Fix: SEGV when failed to remove files

### DIFF
--- a/shell.c
+++ b/shell.c
@@ -5961,13 +5961,15 @@ static int cmd_remove(ShellContext *context, struct args *arg)
 	}
 
 	res = pcs_delete(context->pcs, &slist);
-	if (!res) {
+	if (!res || res->error != 0) {
 		fprintf(stderr, "Error: %s path=%s.\n", pcs_strerror(context->pcs), slist.string);
+		if (res)
+			pcs_pan_api_res_destroy(res);
 		pcs_free(slist.string);
 		return -1;
 	}
 	info = res->info_list;
-	if (info->info.error) {
+	if (info && info->info.error) {
 		fprintf(stderr, "Error: unknow path=%s. \n", slist.string);
 		pcs_pan_api_res_destroy(res);
 		pcs_free(slist.string);


### PR DESCRIPTION
When server returns as follows, SEGV occurs. One question is that: what does error 2 mean?

17:04:59.519172 IP (tos 0x4, ttl 58, id 18423, offset 0, flags [DF], proto TCP (6), length 439)
        0x0000:  4504 01b7 47f7 4000 3a06 fa6d 7b7d 70da  E...G.@.:..m{}p.
        0x0010:  ac14 646c 0050 eb1e fc8d 353d cb41 069c  ..dl.P....5=.A..
        0x0020:  5018 0041 c290 0000 4854 5450 2f31 2e31  P..A....HTTP/1.1
        0x0030:  2032 3030 204f 4b0d 0a43 6163 6865 2d43  .200.OK..Cache-C
        0x0040:  6f6e 7472 6f6c 3a20 6e6f 2d63 6163 6865  ontrol:.no-cache
        
        0x0150:  2b71 6e46 4d75 2b55 6354 527a 776f 6770  +qnFMu+UcTRzwogp
        0x0160:  4877 7969 450d 0a43 6f6e 7465 6e74 2d4c  HwyiE..Content-L
        0x0170:  656e 6774 683a 2035 380d 0a0d 0a20 200d  ength:.58.......
        0x0180:  0a7b 2265 7272 6e6f 223a 322c 2269 6e66  .{"errno":2,"inf
        0x0190:  6f22 3a5b 5d2c 2272 6571 7565 7374 5f69  o":[],"request_i
        0x01a0:  6422 3a37 3239 3930 3535 3136 3432 3133  d":7299055164213
        0x01b0:  3939 3432 3338 7d                        994238}
