### PR TITLE
Fix build steps for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ C/C++写的一个百度网盘工具，可以在linux终端中使用。
 	brew install openssl
 ### 3. 编译源代码
     cd BaiduPCS
+    export LDFLAGS=-L/usr/local/opt/openssl/lib
+    export CPPFLAGS=-I/usr/local/opt/openssl/include
+    autoreconf
+    ./configure
     make clean
     make
     make install #将安装到/usr/local/bin下


### PR DESCRIPTION
macOS 上编译需要指定 OpenSSL 库目录，`autoreconf` 为了解决 Automake 版本冲突。