### PR TITLE
mac os add wchar.h

### DIFF
--- a/pcs/utf8.c
+++ b/pcs/utf8.c
@@ -25,7 +25,7 @@ typedef uint32_t u_int32_t;
 #else
 #include <alloca.h>
 #endif
-
+#include <wchar.h>
 #include "utf8.h"
 
 static const u_int32_t offsetsFromUTF8[6] = {


### PR DESCRIPTION
Mac OS  lost wchar.h  header to build the utf8.c wprintf(),so I add that 

here is the (url)https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/wprintf.3.html